### PR TITLE
Implement polyfill because Linux does not have an async version of data(for:).

### DIFF
--- a/Sources/D1KitFoundation/URLSession+Linux.swift
+++ b/Sources/D1KitFoundation/URLSession+Linux.swift
@@ -1,0 +1,19 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+
+extension URLSession {
+  func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+    return try await withCheckedThrowingContinuation { continuation in
+      let task = self.dataTask(with: request) { (data, response, error) in
+        guard let data = data, let response = response else {
+          let error = error ?? URLError(.badServerResponse)
+          return continuation.resume(throwing: error)
+        }
+        continuation.resume(returning: (data, response))
+      }
+      task.resume()
+    }
+  }
+}
+#endif


### PR DESCRIPTION
The async version of the URLSession methods are few implemented in the Linux version of Swift. Therefore, if we try to build this project in a Linux environment, line 20 of URLSessionHTTPClient.swift will produce a compilation error.

https://github.com/sidepelican/D1Kit/blob/f1b8e5146328df6e2029a7779d3bf23fc209e3eb/Sources/D1KitFoundation/URLSessionHTTPClient. swift#L20

See also: https://github.com/apple/swift-corelibs-foundation/issues/3205

To solve this problem in the Linux environment, provide own implementation of the async version, which wraps the callback version implementation.