### PR TITLE
Add iOS deployment target to 13+

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "D1Kit",
-    platforms: [.macOS(.v13)],
+    platforms: [.macOS(.v13), .iOS(.v13)],
     products: [
         .library(name: "D1Kit", targets: ["D1Kit"]),
     ],


### PR DESCRIPTION
The following compile error occurs when building against an iOS target.

```
D1Kit/Sources/D1Kit/HTTPClient.swift:5:55 Concurrency is only available in iOS 13.0.0 or newer
```

Set the deployment target to 13+ to make it compile against the iOS target.
