### PR TITLE
Fix http client

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "D1Kit", targets: ["D1Kit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-http-types.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-http-types.git", from: "1.3.0"),
     ],
     targets: [
         .target(

--- a/Sources/D1KitFoundation/URLSession+Linux.swift
+++ b/Sources/D1KitFoundation/URLSession+Linux.swift
@@ -15,5 +15,17 @@ extension URLSession {
       task.resume()
     }
   }
+  func upload(for request: URLRequest, from data: Data?) async throws -> (Data, URLResponse) {
+    return try await withCheckedThrowingContinuation { continuation in
+      let task = self.uploadTask(with: request, from: data) { (data, response, error) in
+        guard let data = data, let response = response else {
+          let error = error ?? URLError(.badServerResponse)
+          return continuation.resume(throwing: error)
+        }
+        continuation.resume(returning: (data, response))
+      }
+      task.resume()
+    }
+  }
 }
 #endif

--- a/Sources/D1KitFoundation/URLSession+Linux.swift
+++ b/Sources/D1KitFoundation/URLSession+Linux.swift
@@ -1,7 +1,9 @@
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
+#endif
 
+#if compiler(<6)
 extension URLSession {
   func data(for request: URLRequest) async throws -> (Data, URLResponse) {
     return try await withCheckedThrowingContinuation { continuation in

--- a/Sources/D1KitFoundation/URLSessionHTTPClient.swift
+++ b/Sources/D1KitFoundation/URLSessionHTTPClient.swift
@@ -6,22 +6,13 @@ import FoundationNetworking
 import HTTPTypes
 import HTTPTypesFoundation
 
-private enum HTTPTypeConversionError: Error {
-    case failedToConvertHTTPRequestToURLRequest
-    case failedToConvertURLResponseToHTTPResponse
-}
-
 extension URLSession: HTTPClientProtocol {
     public func execute(_ request: HTTPRequest, body: Data?) async throws -> (Data, HTTPResponse) {
-        guard var urlRequest = URLRequest(httpRequest: request) else {
-            throw HTTPTypeConversionError.failedToConvertHTTPRequestToURLRequest
+        if let body {
+          try await self.upload(for: request, from: body)
+        } else {
+          try await self.data(for: request)
         }
-        urlRequest.httpBody = body
-        let (data, urlResponse) = try await self.data(for: urlRequest)
-        guard let response = (urlResponse as? HTTPURLResponse)?.httpResponse else {
-            throw HTTPTypeConversionError.failedToConvertURLResponseToHTTPResponse
-        }
-        return (data, response)
     }
 }
 


### PR DESCRIPTION
- remove URLRequest
- add URLSession upload async method for Swift 5
  - URLSession in Swift 6 has async method
  - https://github.com/apple/swift-corelibs-foundation/pull/4970
- fix `extension URLSession: HTTPClientProtocol`